### PR TITLE
strip tags recursively

### DIFF
--- a/lib/string.js
+++ b/lib/string.js
@@ -442,9 +442,12 @@ string.js - Copyright (C) 2012-2014, JP Richardson <jprichardson@gmail.com>
         return new this.constructor(this.s)
       }
       var s = this.s, args = arguments.length > 0 ? arguments : [''];
-      multiArgs(args, function(tag) {
-        s = s.replace(RegExp('<\/?' + tag + '[^<>]*>', 'gi'), '');
-      });
+      function stripRecursively(tag) {
+        var regex = RegExp('<\/?' + tag + '[^<>]*>', 'gi');
+        s = s.replace(regex, '');
+        if (s.match(regex)) stripRecursively(tag);
+      }
+      multiArgs(args, stripRecursively)
       return new this.constructor(s);
     },
 

--- a/test/string.test.js
+++ b/test/string.test.js
@@ -656,6 +656,7 @@
         T (S(undefined).stripTags().s === undefined)
         T (S('<p>just <b>some</b> text</p>').stripTags().s === 'just some text')
         T (S('<p>just <b>some</b> text</p>').stripTags('p').s === 'just <b>some</b> text')
+        T (S('PEKO<<x>script src="https://www.google.com/complete/search?client=chrome&q=123&jsonp=alert(document.domain)//"></<x>script>MIKO').stripTags().s === 'PEKOMIKO')
       })
     })
 


### PR DESCRIPTION
目前的 stripTags 只 replace 一次, 沒辦法把惡意的 html 脫乾淨造成有些服務會被 XSS
```javascript
let maliciousString = 'PEKO<<x>script src="https://www.google.com/complete/search?client=chrome&q=123&jsonp=alert(document.domain)//"></<x>script>MIKO'
S(maliciousString).stripTags().s // => 'PEKO<script src="https://www.google.com/complete/search?client=chrome&q=123&jsonp=alert(document.domain)//"></script>MIKO'
```

修正後
```javascript
S(maliciousString).stripTags().s // => 'PEKOMIKO'
```